### PR TITLE
Uppercased a "should" that I think was missed.

### DIFF
--- a/device-support-requirements.md
+++ b/device-support-requirements.md
@@ -336,7 +336,7 @@ __Software deviations are defined as exemptions granted for software requirement
 * Maintainers MUST document for users on the Wiki a valid Recovery image by which to install LineageOS zip files.
 * Devices that do not have traditional Recovery images MUST support & document another means of installation for LineageOS zip files.
 * Maintainers SHOULD verify that Teamwin Recovery Project (TWRP) official distributions work for LineageOS installation.
-* Failures in official TWRP recoveries should be raised with the TWRP team or remedied by the maintainer.
+* Failures in official TWRP recoveries SHOULD be raised with the TWRP team or remedied by the maintainer.
 * Maintainers SHOULD provide a custom recovery link in Wiki documentation if TWRP does not officially support their device.
 
 


### PR DESCRIPTION
Line 339 "Failures in official TWRP recoveries..." was changed. I uppercased an instance of "should" that I believe was missed in a document revision.

